### PR TITLE
Don't hold on to a single request store

### DIFF
--- a/lib/sea_shanty.rb
+++ b/lib/sea_shanty.rb
@@ -56,7 +56,7 @@ module SeaShanty
   end
 
   def request_store
-    @request_store ||= RequestStore.new(configuration)
+    RequestStore.new(configuration)
   end
 
   def configuration_overwrite(env_var, value)


### PR DESCRIPTION
The RequestStore is cheap to create new instances of, so there is no reason to memoize it.

The lifetime of a memoized request store might create problems, when the tests create and delete tmp storage dirs.

This might fix that 🤞